### PR TITLE
Initial stake module specs

### DIFF
--- a/docs/stake.md
+++ b/docs/stake.md
@@ -13,7 +13,7 @@ The stake module performs time-constrained validator delegations.
 
 ### DelegationQueue (FIFO)
 
-* DelegationQueue: 0x01 | format(expire_time) | post_id | stake_id -> Delegation
+* DelegationQueue: 0x01 | format(expire_time) | vendor_id | post_id -> Delegation
 
 ```go
 type Delegation struct {

--- a/docs/stake.md
+++ b/docs/stake.md
@@ -1,0 +1,48 @@
+# Stake module specification
+
+The stake module performs time-constrained validator delegations.
+
+## Dependencies
+
+* x/bank
+* x/staking
+    - `UnbondingPeriod` = 3 days
+    - `MaxEntries` = 7+
+
+## State
+
+### DelegationQueue (FIFO)
+
+* DelegationQueue: 0x01 | format(expire_time) | post_id | stake_id -> Delegation
+
+```go
+type Delegation struct {
+    DelegatorAddr sdk.AccAddress
+    ValidatorAddr sdk.ValAddress
+    Amount        sdk.Dec
+}
+```
+
+## Messages
+
+### MsgDelegate
+
+* Call `Delegate()` in the staking module
+* Add a new `Delegation` to the end of `DelegationQueue`
+
+## End-Block
+
+* Check `expire_time` in `DelegationQueue` against the current block time
+* Process all delegations that have an `expire_time` that exceeds the current block time
+    - Undelegate
+    - Distribute rewards
+
+## Events
+
+### EndBlocker
+
+| Type              | Attribute Key         | Attribute Value           |
+| ----------------- | --------------------- | ------------------------- |
+| complete_stake    | amount                | {Amount}                  |
+| complete_stake    | delegator             | {delegatorAddress}        |
+


### PR DESCRIPTION
Fixes #3.

This wraps the Cosmos `x/staking` module, making delegations unbond after a certain period of time.

Storing delegations with a key tuple of `expire_time | post_id | stake_id` in a FIFO queue. 

`post_id`: tweet id
`stake_id`: auto-incrementing `uint64` for each like

This allows the end blocker to only peek the first element on each block. Then it can get all stakes for a post by iterating on `expire_time | post_id` , and pop each element when processed. So only currently active stakes are stored on chain.

It will be the duty of the the indexer to keep track of stake and tweet relationships long-term.