### PR TITLE
Added default unbonding period of 72h to init genesis

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,6 +36,8 @@ steps:
       source:
         - bin/
     when:
+      event:
+        - push
       branch: master
   - name: deploy-devnet-srv
     image: appleboy/drone-ssh
@@ -50,6 +52,8 @@ steps:
       script:
         - sh ~/deploy-devnet.sh
     when:
+      event:
+        - push
       branch: master
   - name: slack
     image: plugins/slack
@@ -60,6 +64,6 @@ steps:
       status: [success, failure]
 ---
 kind: signature
-hmac: 062bf547b4423ec6c610364e3631e7f58c3bf51a72e433eafc02b7fef5ef057b
+hmac: c358f1cabf97c70f1fada83eb8e55ea6da8c682bc0b0c7488d6d04b213936cb9
 
 ...

--- a/app/app.go
+++ b/app/app.go
@@ -42,8 +42,11 @@ import (
 
 const (
 	appName = "rocket"
-	// DefaultStakeDenom for rocket hub
+	// DefaultStakeDenom for Stakebird
 	DefaultStakeDenom = "ufuel"
+
+	// DefaultUnbondingPeriod for Stakebird
+	DefaultUnbondingPeriod = "72h"
 
 	// Bech32MainPrefix defines the Bech32 prefix of an account's address
 	Bech32MainPrefix = "cosmos"

--- a/cmd/rocketd/tesnet.go
+++ b/cmd/rocketd/tesnet.go
@@ -240,7 +240,8 @@ func InitTestnet(
 		srvconfig.WriteConfigFile(rocketConfigFilePath, rocketConfig)
 	}
 	stakeDenom := viper.GetString(flagStakeDenom)
-	if err := initGenFiles(cdc, mbm, chainID, stakeDenom, genAccounts, genBalances, genFiles, numValidators); err != nil {
+	unbondingPeriod := viper.GetString(flagUnbondingPeriod)
+	if err := initGenFiles(cdc, mbm, chainID, stakeDenom, unbondingPeriod, genAccounts, genBalances, genFiles, numValidators); err != nil {
 		return err
 	}
 
@@ -257,7 +258,7 @@ func InitTestnet(
 }
 
 func initGenFiles(
-	cdc *codec.Codec, mbm module.BasicManager, chainID, stakeDenom string,
+	cdc *codec.Codec, mbm module.BasicManager, chainID, stakeDenom, unbondingPeriod string,
 	genAccounts []authexported.GenesisAccount, genBalances []bank.Balance,
 	genFiles []string, numValidators int,
 ) error {
@@ -288,7 +289,7 @@ func initGenFiles(
 		AppState:   appGenStateJSON,
 		Validators: nil,
 	}
-	appState, err := initGenesis(cdc, &genDoc, stakeDenom)
+	appState, err := initGenesis(cdc, &genDoc, stakeDenom, unbondingPeriod)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Made the unbonding period the same as the voting period to prevent users from not being able to stake due to funds being locked up. The default value can be set during chain init.